### PR TITLE
doc_fix: Moved config to proper level

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ To generate images from PlantUML description add following dependency to your _p
       <artifactId>plantuml-maven-plugin</artifactId>
       <version>1.5</version>
       <configuration>
+        <truncatePattern>src/main/*</truncatePattern>
         <sourceFiles>
           <directory>${basedir}</directory>
-          <truncatePattern>src/main/*</truncatePattern>
           <includes>
             <include>src/main/plantuml/**/*.txt</include>
           </includes>


### PR DESCRIPTION
Super minor documentation issue where the config was in the sourceFiles block which is a FileSet and has no where to put the custom truncatePattern configuration